### PR TITLE
Fix Command Arg Parsing

### DIFF
--- a/Tasks/CordovaBuild/cordova-task.js
+++ b/Tasks/CordovaBuild/cordova-task.js
@@ -305,7 +305,12 @@ function execBuild(code) {
 
     // Add optional additional args
     var rawArgs = taskLibrary.getInput('cordovaArgs', /* required */ false);
-    var args = taskLibrary.args(rawArgs);
+    var args = rawArgs.match(/([^" ]*("[^"]*")[^" ]*)|[^" ]+/g);
+    //remove double quotes from each string in args as child_process.spawn() cannot handle literla quotes as part of arguments
+    for (var i = 0; i < args.length; i++) {
+        args[i] = args[i].replace(/"/g, "");
+    }
+    
     if (args) {
         args.forEach(function (arg) {
             if (arg != '--') {  		// Double-double dash syntax not required when invoking cordova-lib directly

--- a/Tasks/CordovaBuild/package.json
+++ b/Tasks/CordovaBuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-task-cordova-build",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A VSO build task for building Cordova apps.",
   "author": "Microsoft",
   "license": "MIT",

--- a/Tasks/CordovaCommand/cordova-command-task.js
+++ b/Tasks/CordovaCommand/cordova-command-task.js
@@ -40,13 +40,11 @@ function callCordova() {
 
 
         var rawCmd = taskLibrary.getInput('cordovaCommand', /* required */ true);
-        var cmd = taskLibrary.args(rawCmd);
-        commandRunner.arg(cmd);
+        commandRunner.arg(rawCmd);
         
         var rawArgs = taskLibrary.getInput('cordovaArgs', /* required */ false);
-        var args = taskLibrary.args(rawArgs);
-        if (args) {
-            commandRunner.arg(args);
+        if (rawArgs) {
+            commandRunner.arg(rawArgs);
         }
 
         return commandRunner.exec();

--- a/Tasks/CordovaCommand/package.json
+++ b/Tasks/CordovaCommand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-task-cordova-command",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A VSO build task for running Cordova commands.",
   "author": "Microsoft",
   "license": "MIT",

--- a/Tasks/IonicCommand/ionic-command-task.js
+++ b/Tasks/IonicCommand/ionic-command-task.js
@@ -44,12 +44,10 @@ function callIonic() {
         var commandRunner = new taskLibrary.ToolRunner(ionicCmd);
         
         var rawCmd = taskLibrary.getInput('ionicCommand', /* required */ false);
-        var cmd = taskLibrary.args(rawCmd);
-        commandRunner.arg(cmd);
+        commandRunner.arg(rawCmd);
         var rawArgs = taskLibrary.getInput('ionicArgs', /* required */ false);
-        var args = taskLibrary.args(rawArgs);
-        if (args) {
-            commandRunner.arg(args);
+        if (rawArgs) {
+            commandRunner.arg(rawArgs);
         }
 
         return commandRunner.exec();

--- a/Tasks/IonicCommand/package.json
+++ b/Tasks/IonicCommand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-task-ionic-command",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A VSO build task for running Ionic commands.",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
Again. Update command arg parsing to use Toolrunner arg parsing logic. This should be the actual correct fix for this.

@Chuxel @dlevine82 @bryanmacfarlane 