### PR TITLE
fixing passing of env vars to properly not set null values

### DIFF
--- a/Tasks/CordovaBuild/exec.js
+++ b/Tasks/CordovaBuild/exec.js
@@ -7,13 +7,21 @@ var childProcess = require("child_process");
 var path = require("path");
 var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
-process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable('BUILD_SOURCEDIRECTORY', false);
-process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable('BUILD_SOURCESDIRECTORY', false);
+var buildSourceDir = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
+var buildSourcesDir = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+
+if (buildSourceDir) {
+    process.env["BUILD_SOURCEDIRECTORY"] = buildSourceDir;
+}
+
+if (buildSourcesDir) {
+    process.env["BUILD_SOURCESDIRECTORY"] = buildSourcesDir;
+}
 
 var inputs = ["CWD", "XCODEDEVELOPERDIR", "CONFIGURATION", "ARCHS", "PLATFORM", "TARGETEMULATOR", "WINDOWSAPPX", "WINDOWSONLY", "WINDOWSPHONEONLY", "UNLOCKDEFAULTKEYCHAIN", "DEFAULTKEYCHAINPASSWORD",
     "P12", "P12PWD", "IOSSIGNINGIDENTITY", "PROVPROFILEUUID", "PROVPROFILE", "REMOVEPROFILE", "ANTBUILD", "KEYSTOREFILE", "KEYSTOREPASS", "KEYSTOREALIAS", "KEYPASS", "OUTPUTPATTERN", "CORDOVAARGS", "CORDOVAVERSION"];
-    
-for (var i = 0; i < inputs.length; i ++) {
+
+for (var i = 0; i < inputs.length; i++) {
     var inputValue = taskLibrary.getInput(inputs[i], false);
     if (inputValue) {
         process.env["INPUT_" + inputs[i]] = inputValue;

--- a/Tasks/CordovaBuild/exec.js
+++ b/Tasks/CordovaBuild/exec.js
@@ -9,31 +9,16 @@ var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
 process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable('BUILD_SOURCEDIRECTORY', false);
 process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable('BUILD_SOURCESDIRECTORY', false);
-process.env["INPUT_CWD"] = taskLibrary.getInput('CWD', false);
-process.env["INPUT_XCODEDEVELOPERDIR"] = taskLibrary.getInput('XCODEDEVELOPERDIR', false);
-process.env["INPUT_CONFIGURATION"] = taskLibrary.getInput('CONFIGURATION', false);
-process.env["INPUT_ARCHS"] = taskLibrary.getInput('ARCHS', false);
-process.env["INPUT_PLATFORM"] = taskLibrary.getInput('PLATFORM', false);
-process.env["INPUT_TARGETEMULATOR"] = taskLibrary.getInput('TARGETEMULATOR', false);
-process.env["INPUT_WINDOWSAPPX"] = taskLibrary.getInput('WINDOWSAPPX', false);
-process.env["INPUT_WINDOWSONLY"] = taskLibrary.getInput('WINDOWSONLY', false);
-process.env["INPUT_WINDOWSPHONEONLY"] = taskLibrary.getInput('WINDOWSPHONEONLY', false);
-process.env["INPUT_UNLOCKDEFAULTKEYCHAIN"] = taskLibrary.getInput('UNLOCKDEFAULTKEYCHAIN', false);
-process.env["INPUT_DEFAULTKEYCHAINPASSWORD"] = taskLibrary.getInput('DEFAULTKEYCHAINPASSWORD', false);
-process.env["INPUT_P12"] = taskLibrary.getInput('P12', false);
-process.env["INPUT_P12PWD"] = taskLibrary.getInput('P12PWD', false);
-process.env["INPUT_IOSSIGNINGIDENTITY"] = taskLibrary.getInput('IOSSIGNINGIDENTITY', false);
-process.env["INPUT_PROVPROFILEUUID"] = taskLibrary.getInput('PROVPROFILEUUID', false);
-process.env["INPUT_PROVPROFILE"] = taskLibrary.getInput('PROVPROFILE', false);
-process.env["INPUT_REMOVEPROFILE"] = taskLibrary.getInput('REMOVEPROFILE', false);
-process.env["INPUT_ANTBUILD"] = taskLibrary.getInput('ANTBUILD', false);
-process.env["INPUT_KEYSTOREFILE"] = taskLibrary.getInput('KEYSTOREFILE', false);
-process.env["INPUT_KEYSTOREPASS"] = taskLibrary.getInput('KEYSTOREPASS', false);
-process.env["INPUT_KEYSTOREALIAS"] = taskLibrary.getInput('KEYSTOREALIAS', false);
-process.env["INPUT_KEYPASS"] = taskLibrary.getInput('KEYPASS', false);
-process.env["INPUT_OUTPUTPATTERN"] = taskLibrary.getInput('OUTPUTPATTERN', false);
-process.env["INPUT_CORDOVAARGS"] = taskLibrary.getInput('CORDOVAARGS', false);
-process.env["INPUT_CORDOVAVERSION"] = taskLibrary.getInput('CORDOVAVERSION', false);
+
+var inputs = ["CWD", "XCODEDEVELOPERDIR", "CONFIGURATION", "ARCHS", "PLATFORM", "TARGETEMULATOR", "WINDOWSAPPX", "WINDOWSONLY", "WINDOWSPHONEONLY", "UNLOCKDEFAULTKEYCHAIN", "DEFAULTKEYCHAINPASSWORD",
+    "P12", "P12PWD", "IOSSIGNINGIDENTITY", "PROVPROFILEUUID", "PROVPROFILE", "REMOVEPROFILE", "ANTBUILD", "KEYSTOREFILE", "KEYSTOREPASS", "KEYSTOREALIAS", "KEYPASS", "OUTPUTPATTERN", "CORDOVAARGS", "CORDOVAVERSION"];
+    
+for (var i = 0; i < inputs.length; i ++) {
+    var inputValue = taskLibrary.getInput(inputs[i], false);
+    if (inputValue) {
+        process.env["INPUT_" + inputs[i]] = inputValue;
+    }
+}
 
 var result = childProcess.spawnSync("node",
     [path.join(__dirname, "lib", "node-setup.js"), path.join(__dirname, "lib", "cordova-task.js")],

--- a/Tasks/CordovaBuild/task.json
+++ b/Tasks/CordovaBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "npm"

--- a/Tasks/CordovaBuild/task.json
+++ b/Tasks/CordovaBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 2
     },
     "demands": [
         "npm"

--- a/Tasks/CordovaCommand/exec.js
+++ b/Tasks/CordovaCommand/exec.js
@@ -7,12 +7,20 @@ var childProcess = require("child_process");
 var path = require("path");
 var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
-process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
-process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+var buildSourceDir = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
+var buildSourcesDir = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+
+if (buildSourceDir) {
+    process.env["BUILD_SOURCEDIRECTORY"] = buildSourceDir;
+}
+
+if (buildSourcesDir) {
+    process.env["BUILD_SOURCESDIRECTORY"] = buildSourcesDir;
+}
 
 var inputs = ["CWD", "CORDOVAARGS", "CORDOVAVERSION", "CORDOVACOMMAND"];
-    
-for (var i = 0; i < inputs.length; i ++) {
+
+for (var i = 0; i < inputs.length; i++) {
     var inputValue = taskLibrary.getInput(inputs[i], false);
     if (inputValue) {
         process.env["INPUT_" + inputs[i]] = inputValue;

--- a/Tasks/CordovaCommand/exec.js
+++ b/Tasks/CordovaCommand/exec.js
@@ -9,10 +9,15 @@ var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
 process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
 process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
-process.env["INPUT_CWD"] = taskLibrary.getInput("CWD", false);
-process.env["INPUT_CORDOVAARGS"] = taskLibrary.getInput("CORDOVAARGS", false);
-process.env["INPUT_CORDOVAVERSION"] = taskLibrary.getInput("CORDOVAVERSION", false);
-process.env["INPUT_CORDOVACOMMAND"] = taskLibrary.getInput("CORDOVACOMMAND", false);
+
+var inputs = ["CWD", "CORDOVAARGS", "CORDOVAVERSION", "CORDOVACOMMAND"];
+    
+for (var i = 0; i < inputs.length; i ++) {
+    var inputValue = taskLibrary.getInput(inputs[i], false);
+    if (inputValue) {
+        process.env["INPUT_" + inputs[i]] = inputValue;
+    }
+}
 
 var result = childProcess.spawnSync("node",
     [path.join(__dirname, "lib", "node-setup.js"), path.join(__dirname, "lib", "cordova-command-task.js")],

--- a/Tasks/CordovaCommand/lib/cordova-command-task.js
+++ b/Tasks/CordovaCommand/lib/cordova-command-task.js
@@ -13,7 +13,9 @@ var spawnSync = require("child_process").spawnSync;
 var buildSourceDirectory = process.env["BUILD_SOURCEDIRECTORY"] || process.env["BUILD_SOURCESDIRECTORY"];
 //Process working directory
 var workingDirectory = process.env["INPUT_CWD"] || buildSourceDirectory;
-process.chdir(workingDirectory);
+if (workingDirectory) {
+    process.chdir(workingDirectory);
+}
 
 callCordova().fail(function (err) {
     console.error(err.message);

--- a/Tasks/CordovaCommand/task.json
+++ b/Tasks/CordovaCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "npm"

--- a/Tasks/CordovaCommand/task.json
+++ b/Tasks/CordovaCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 2
     },
     "demands": [
         "npm"

--- a/Tasks/IonicCommand/exec.js
+++ b/Tasks/IonicCommand/exec.js
@@ -7,12 +7,20 @@ var childProcess = require("child_process");
 var path = require("path");
 var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
-process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
-process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+var buildSourceDir = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
+var buildSourcesDir = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+
+if (buildSourceDir) {
+    process.env["BUILD_SOURCEDIRECTORY"] = buildSourceDir;
+}
+
+if (buildSourcesDir) {
+    process.env["BUILD_SOURCESDIRECTORY"] = buildSourcesDir;
+}
 
 var inputs = ["CWD", "CORDOVAVERSION", "IONICARGS", "IONICVERSION", "IONICCOMMAND"];
-    
-for (var i = 0; i < inputs.length; i ++) {
+
+for (var i = 0; i < inputs.length; i++) {
     var inputValue = taskLibrary.getInput(inputs[i], false);
     if (inputValue) {
         process.env["INPUT_" + inputs[i]] = inputValue;

--- a/Tasks/IonicCommand/exec.js
+++ b/Tasks/IonicCommand/exec.js
@@ -9,11 +9,15 @@ var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
 process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
 process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
-process.env["INPUT_CWD"] = taskLibrary.getInput("CWD", false);
-process.env["INPUT_CORDOVAVERSION"] = taskLibrary.getInput("CORDOVAVERSION", false)
-process.env["INPUT_IONICARGS"] = taskLibrary.getInput("IONICARGS", false);
-process.env["INPUT_IONICVERSION"] = taskLibrary.getInput("IONICVERSION", false);
-process.env["INPUT_IONICCOMMAND"] = taskLibrary.getInput("IONICCOMMAND", false);
+
+var inputs = ["CWD", "CORDOVAVERSION", "IONICARGS", "IONICVERSION", "IONICCOMMAND"];
+    
+for (var i = 0; i < inputs.length; i ++) {
+    var inputValue = taskLibrary.getInput(inputs[i], false);
+    if (inputValue) {
+        process.env["INPUT_" + inputs[i]] = inputValue;
+    }
+}
 
 var result = childProcess.spawnSync("node",
     [path.join(__dirname, "lib", "node-setup.js"), path.join(__dirname, "lib", "ionic-command-task.js")],

--- a/Tasks/IonicCommand/lib/ionic-command-task.js
+++ b/Tasks/IonicCommand/lib/ionic-command-task.js
@@ -12,7 +12,9 @@ var spawnSync = require("child_process").spawnSync;
 var buildSourceDirectory = process.env["BUILD_SOURCEDIRECTORY"] || process.env["BUILD_SOURCESDIRECTORY"];
 //Process working directory
 var workingDirectory = process.env["INPUT_CWD"] || buildSourceDirectory;
-process.chdir(workingDirectory);
+if (workingDirectory) {
+    process.chdir(workingDirectory);
+}
 
 callIonic().fail(function (err) {
     console.error(err.message);
@@ -38,7 +40,7 @@ function callIonic() {
         });
     }).then(function (ionicModule) {
         console.log("Ionic Module Path: " + ionicModule.path);
-        
+
         var ionicExecutable = process.platform == "win32" ? "ionic.cmd" : "ionic";
         var ionicCmd = path.resolve(ionicModule.path, "..", ".bin", ionicExecutable);
         var rawCmd = process.env["INPUT_IONICCOMMAND"];

--- a/Tasks/IonicCommand/task.json
+++ b/Tasks/IonicCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "npm"

--- a/Tasks/IonicCommand/task.json
+++ b/Tasks/IonicCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 2
     },
     "demands": [
         "npm"

--- a/Tasks/PhoneGapCommand/exec.js
+++ b/Tasks/PhoneGapCommand/exec.js
@@ -7,15 +7,23 @@ var childProcess = require("child_process");
 var path = require("path");
 var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
-process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
-process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+var buildSourceDir = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
+var buildSourcesDir = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
+
+if (buildSourceDir) {
+    process.env["BUILD_SOURCEDIRECTORY"] = buildSourceDir;
+}
+
+if (buildSourcesDir) {
+    process.env["BUILD_SOURCESDIRECTORY"] = buildSourcesDir;
+}
 
 var inputs = ["CWD", "PHONEGAPARGS", "PHONEGAPVERSION", "PHONEGAPCOMMAND"];
-    
-for (var i = 0; i < inputs.length; i ++) {
+
+for (var i = 0; i < inputs.length; i++) {
     var inputValue = taskLibrary.getInput(inputs[i], false);
     if (inputValue) {
-        process.env[inputs[i]] = inputValue;
+        process.env["INPUT_" + inputs[i]] = inputValue;
     }
 }
 

--- a/Tasks/PhoneGapCommand/exec.js
+++ b/Tasks/PhoneGapCommand/exec.js
@@ -9,10 +9,15 @@ var taskLibrary = require("./lib/vsts-task-lib-proxy.js");
 
 process.env["BUILD_SOURCEDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCEDIRECTORY", false);
 process.env["BUILD_SOURCESDIRECTORY"] = taskLibrary.getVariable("BUILD_SOURCESDIRECTORY", false);
-process.env["INPUT_CWD"] = taskLibrary.getInput("CWD", false);
-process.env["INPUT_PHONEGAPARGS"] = taskLibrary.getInput("PHONEGAPARGS", false);
-process.env["INPUT_PHONEGAPVERSION"] = taskLibrary.getInput("PHONEGAPVERSION", false);
-process.env["INPUT_PHONEGAPCOMMAND"] = taskLibrary.getInput("PHONEGAPCOMMAND", false);
+
+var inputs = ["CWD", "PHONEGAPARGS", "PHONEGAPVERSION", "PHONEGAPCOMMAND"];
+    
+for (var i = 0; i < inputs.length; i ++) {
+    var inputValue = taskLibrary.getInput(inputs[i], false);
+    if (inputValue) {
+        process.env[inputs[i]] = inputValue;
+    }
+}
 
 var result = childProcess.spawnSync("node",
     [path.join(__dirname, "lib", "node-setup.js"), path.join(__dirname, "lib", "phonegap-command-task.js")],

--- a/Tasks/PhoneGapCommand/lib/phonegap-command-task.js
+++ b/Tasks/PhoneGapCommand/lib/phonegap-command-task.js
@@ -12,7 +12,9 @@ var spawnSync = require("child_process").spawnSync;
 var buildSourceDirectory = process.env["BUILD_SOURCEDIRECTORY"] || process.env["BUILD_SOURCESDIRECTORY"];
 //Process working directory
 var workingDirectory = process.env["INPUT_CWD"] || buildSourceDirectory;
-process.chdir(workingDirectory);
+if (workingDirectory) {
+    process.chdir(workingDirectory);
+}
 
 callPhoneGap().fail(function (err) {
     console.error(err.message);

--- a/Tasks/PhoneGapCommand/task.json
+++ b/Tasks/PhoneGapCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "npm"

--- a/Tasks/PhoneGapCommand/task.json
+++ b/Tasks/PhoneGapCommand/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 2
     },
     "demands": [
         "npm"

--- a/lib/node-manager.js
+++ b/lib/node-manager.js
@@ -22,31 +22,31 @@ var nodePath;
 function setupMinNode(minVersion, targetVersion, /*optional*/ installNpmOnWindows) {
     var nodeCli = shelljs.which("node");
     return exec("\"" + nodeCli + "\" --version")
-        .then(function(version) {
-            version = removeExecOutputNoise(version);
-            if (semver.lt(version, minVersion)) {
-                console.log("Node < " + minVersion + ", downloading node " + targetVersion);
-                return setupNode(targetVersion, installNpmOnWindows);
-            } else {
-                console.log("Found node " + version);
-                nodePath = path.dirname(nodeCli);
-            }
-        });
+        .then(function (version) {
+        version = removeExecOutputNoise(version);
+        if (semver.lt(version, minVersion)) {
+            console.log("Node < " + minVersion + ", downloading node " + targetVersion);
+            return setupNode(targetVersion, installNpmOnWindows);
+        } else {
+            console.log("Found node " + version);
+            nodePath = path.dirname(nodeCli);
+        }
+    });
 }
 
 function setupMaxNode(maxVersion, targetVersion, /*optional*/ installNpmOnWindows) {
     var nodeCli = shelljs.which("node");
     return exec("\"" + nodeCli + "\" --version")
-        .then(function(version) {
-            version = removeExecOutputNoise(version);
-            if (semver.gt(version, maxVersion)) {
-                console.log("Node > " + maxVersion + ", downloading node " + targetVersion);
-                return setupNode(targetVersion, installNpmOnWindows);
-            } else {
-                console.log("Found node " + version);
-                nodePath = path.dirname(nodeCli);
-            }
-        });
+        .then(function (version) {
+        version = removeExecOutputNoise(version);
+        if (semver.gt(version, maxVersion)) {
+            console.log("Node > " + maxVersion + ", downloading node " + targetVersion);
+            return setupNode(targetVersion, installNpmOnWindows);
+        } else {
+            console.log("Found node " + version);
+            nodePath = path.dirname(nodeCli);
+        }
+    });
 }
 
 function useSystemNode() {
@@ -103,15 +103,16 @@ function setupNode(targetVersion, /*optional*/ installNpmOnWindows) {
         // Download node version if not found - npm also grabbed, installed, and used     
         if (!fs.existsSync(nodePath)) {
             var gzPath = path.join(NODE_VERSION_CACHE, folderName + ".tar.gz");
-            console.log("Downloading " + gzPath)
-            dlNodeCommand.arg("-o \"" + gzPath + "\" http://nodejs.org/dist/v" + targetVersion + "/" + folderName + ".tar.gz");
-            return dlNodeCommand.exec()
-                .then(function() {
-                    console.log("Extracting " + gzPath);
-                    var shellBash = shelljs.which("bash");
-                    var args = ["-c \"cd " + NODE_VERSION_CACHE.replace(" ", "\\ ") + "; gunzip -c " + folderName + ".tar.gz | tar xopf -\""];
-                    return spawn(shellBash, args, { stdio: "inherit" });
-                });
+            console.log("Downloading " + gzPath);
+            var curlArgs = ["-o \"" + gzPath + "\" http://nodejs.org/dist/v" + targetVersion + "/" + folderName + ".tar.gz"];
+
+            return spawn(curlPath, curlArgs, { stdio: "inherit" })
+                .then(function () {
+                console.log("Extracting " + gzPath);
+                var shellBash = shelljs.which("bash");
+                var args = ["-c \"cd " + NODE_VERSION_CACHE.replace(" ", "\\ ") + "; gunzip -c " + folderName + ".tar.gz | tar xopf -\""];
+                return spawn(shellBash, args, { stdio: "inherit" });
+            });
         } else {
             return Q();
         }
@@ -128,7 +129,7 @@ module.exports = {
     setupMaxNode: setupMaxNode,
     setupMinNode: setupMinNode,
     useSystemNode: useSystemNode,
-    getNodePath: function() {
+    getNodePath: function () {
         return nodePath;
     }
 }

--- a/mobiledevopscordovaextension.json
+++ b/mobiledevopscordovaextension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "cordova-extension",
     "name": "Cordova Build",
-    "version": "1.3.0",
+    "version": "1.3.2",
     "publisher": "ms-vsclient",
     "description": "Streamline CI setup for your Apache Cordova, PhoneGap, Ionic, or Cordova CLI compatible app using a set of useful pre-defined build steps.",
     "categories": [


### PR DESCRIPTION
Passing of environment variables from the exec.js to node-setup was setting all variables to a value, even if it was the string "null". This was causing subsequent checks of the environment to fail.

Update the exec logic to not set the values if null is returned from the task lib's getInput.

This should address a multitude of issues, including all the ones mentioned at https://github.com/Microsoft/vsts-cordova-tasks/issues/47

@Chuxel