### PR TITLE
Fixes #40 - added ability to set application id, name and version in config.xml

### DIFF
--- a/Tasks/CordovaBuild/lib/cordova-task.js
+++ b/Tasks/CordovaBuild/lib/cordova-task.js
@@ -10,7 +10,8 @@ var path = require('path'),
     glob = require('glob'),
     xcutils = require('./xcode-task-utils.js'),
     teambuild = require('taco-team-build'),
-    shelljs = require('shelljs');
+    shelljs = require('shelljs'),
+    ConfigParser = require('cordova-common').ConfigParser;
 
 
 // Globals - Easy way to have data available across promises.
@@ -391,6 +392,7 @@ function execBuild(code) {
 
                 return Q();
             }).then(function () {
+                changeCordovaConfig();
                 return teambuild.buildProject(platform, buildArgs)
             }).fin(function () {
                 // Remove xcconfig hook
@@ -404,6 +406,33 @@ function execBuild(code) {
                 }
             });
         });
+}
+
+function changeCordovaConfig() {
+    var config = new ConfigParser(path.join(cwd, 'config.xml'));    
+    if (process.env['INPUT_APPID']) {
+        config.setPackageName(process.env['INPUT_APPID']);
+        console.log("Application id: " + process.env['INPUT_APPID']);
+    }
+    if (process.env['INPUT_APPNAME']) {
+        config.setName(process.env['INPUT_APPNAME']);
+        console.log("Application name: " + process.env['INPUT_APPNAME']);
+    }
+    if (process.env['INPUT_VERSIONBUILDAUTOINCREMENT']) {
+        var arrayVersion = /(\d).(\d).(\d)/.exec(config.version());
+        if (!arrayVersion) {
+            return;
+        }
+        arrayVersion[3]++;
+        arrayVersion.splice(0, 1);
+        var newVersion = arrayVersion.join('.');
+        process.env['INPUT_VERSIONBUILD'] = newVersion;
+    }
+    if (process.env['INPUT_VERSIONBUILD']) {
+        config.setVersion(process.env['INPUT_VERSIONBUILD']);
+        console.log("Application version: " + process.env['INPUT_VERSIONBUILD']);
+    } 
+    config.write();
 }
 
 function stripNewerAndroidArgs(args) {

--- a/Tasks/CordovaBuild/package.json
+++ b/Tasks/CordovaBuild/package.json
@@ -11,6 +11,7 @@
     "semver": "^5.0.3",
     "shelljs": "^0.7.0",
     "taco-team-build": "^0.2.5",
-    "vsts-task-lib": "^0.8.2"
+    "vsts-task-lib": "^0.8.2",
+    "cordova-common": "^2.0.3"
   }
 }

--- a/Tasks/CordovaBuild/task.json
+++ b/Tasks/CordovaBuild/task.json
@@ -265,6 +265,38 @@
             "required":false, 
             "helpMarkDown": "Build for a emulator or simulator instead of devices.",
             "groupName":"advanced"
+        },
+        {
+            "name": "appId",
+            "type": "string",
+            "label": "Application Id",
+            "required": false,
+            "helpMarkDown": "Id application to be compiled (Example: \"io.cordova.myapp12345\"). If it is empty, it will not be changed.",
+            "groupName":"advanced"
+        },
+        {
+            "name": "appName",
+            "type": "string",
+            "label": "Application name",
+            "required": false,
+            "helpMarkDown": "Name of application to be compiled. If it is empty, it will not be changed.",
+            "groupName":"advanced"
+        },
+        {
+            "name": "versionBuild",
+            "type": "string",
+            "label": "Build version",
+            "required": false,
+            "helpMarkDown": "Full build version application (Example: \"0.0.1\"). If it is empty, it will not be changed.",
+            "groupName":"advanced"
+        },
+        {
+            "name": "versionBuildAutoincrement",
+            "type": "boolean",
+            "label": "Autoincrement build version",
+            "required": false,
+            "helpMarkDown": "Autoincrement build version application",
+            "groupName":"advanced"
         }
     ],
     "execution": {


### PR DESCRIPTION
Before the build, the parser config.xml is added.
Settings have been added to the Advanced group (UI was not tested, because to do this, must replace the original extension).