### PR TITLE
Fixes commas from being stripped on the cert name

### DIFF
--- a/lib/xcode-task-utils.js
+++ b/lib/xcode-task-utils.js
@@ -135,7 +135,7 @@ function determineProfile(input) {
 
 function removeExecOutputNoise(input) {
     var output = input + "";
-    output = output.trim().replace( /["\n\r\f\v]/gm, "" ).replace( /,$/, "" );
+    output = output.trim().replace(/["\n\r\f\v]/gm, '').replace(/,$/, '');
     return output;
 }
 

--- a/lib/xcode-task-utils.js
+++ b/lib/xcode-task-utils.js
@@ -135,7 +135,7 @@ function determineProfile(input) {
 
 function removeExecOutputNoise(input) {
     var output = input + "";
-    output = output.trim().replace(/["\n\r\f\v]/gm, '');
+    output = output.trim().replace( /["\n\r\f\v]/gm, "" ).replace( /,$/, "" );
     return output;
 }
 

--- a/lib/xcode-task-utils.js
+++ b/lib/xcode-task-utils.js
@@ -135,7 +135,7 @@ function determineProfile(input) {
 
 function removeExecOutputNoise(input) {
     var output = input + "";
-    output = output.trim().replace(/[",\n\r\f\v]/gm, '');
+    output = output.trim().replace(/["\n\r\f\v]/gm, '');
     return output;
 }
 


### PR DESCRIPTION
Previously a comma in a certificate common name would be removed causing the identity name not to match the available certificate. This modifies that filter on the `xcode-task-utils.js` method named `removeExecOutputNoise`. It will still removing the trailing comma while preserving commas found within the string.